### PR TITLE
解决垂直滑动控件嵌套太深无法滑动的bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha7'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "cn.bleu.slidedetailsdemo"

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -10,9 +10,21 @@
     android:layout_height="match_parent">
 
     <FrameLayout
-        android:id="@+id/slidedetails_front"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <FrameLayout
+                android:id="@+id/slidedetails_front"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+        </FrameLayout>
+    </FrameLayout>
+    <!--<FrameLayout-->
+        <!--android:id="@+id/slidedetails_front"-->
+        <!--android:layout_width="match_parent"-->
+        <!--android:layout_height="match_parent"/>-->
 
     <!--<include layout="@layout/scroll_fragment"/>-->
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue Jul 18 22:54:45 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 14

--- a/library/src/main/java/cn/bleu/widget/slidedetails/SlideDetailsLayout.java
+++ b/library/src/main/java/cn/bleu/widget/slidedetails/SlideDetailsLayout.java
@@ -534,10 +534,10 @@ public class SlideDetailsLayout extends ViewGroup {
             boolean result;
             for (int i = 0; i < vGroup.getChildCount(); i++) {
                 child = vGroup.getChildAt(i);
-                if (child instanceof View) {
-                    result = ViewCompat.canScrollVertically(child, direction);
-                } else {
+                if (child instanceof ViewGroup) {
                     result = innerCanChildScrollVertically(child, direction);
+                } else {
+                    result = ViewCompat.canScrollVertically(child, direction);
                 }
 
                 if (result) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16846621/28347087-9c1c757e-6c67-11e7-8556-3f069e3e7f74.png)
这边代码ViewGroup也是instanceof View，所以导致不会走else的方法，如果ListView的外面多包几层ViewGroup的话ListView就无法滑动了。
![image](https://user-images.githubusercontent.com/16846621/28347053-6869f436-6c67-11e7-899d-2588156dba5e.png)
改为了先instanceof ViewGroup